### PR TITLE
Use `REQUEST_URI` as fallback

### DIFF
--- a/src/AeolusCMS/App.php
+++ b/src/AeolusCMS/App.php
@@ -230,29 +230,24 @@ class App {
     }
 
     private function splitUrl() {
-        self::$url = urldecode(htmlspecialchars(trim($_SERVER['REQUEST_URI'],  '/')));
 
-        if (isset($_GET['url'])) {
-            $url = htmlspecialchars(rtrim($_GET['url'], '/'));
+        $url
+            = isset($_GET['url'])
+            ? $_GET['url']
+            : $_SERVER['REQUEST_URI'];
 
-            $url = explode('/', $url);
+        $url = explode('/', urldecode(htmlspecialchars(trim($url,  '/'))));
 
-            self::$app_data->setAttribute('controller', (isset($url[0]) ? $url[0] : self::$config['url']['default_controller']));
-            self::$app_data->setAttribute('action', (isset($url[1]) ? $url[1] : self::$config['url']['default_action']));
-            self::$app_data->setAttribute('parameter_1', (isset($url[2]) ? $url[2] : null));
-            self::$app_data->setAttribute('parameter_2', (isset($url[3]) ? $url[3] : null));
-            self::$app_data->setAttribute('parameter_3', (isset($url[4]) ? $url[4] : null));
-        } else {
-            $url = array();
-            self::$app_data->setAttribute('controller', self::$config['url']['default_controller']);
-            self::$app_data->setAttribute('action', self::$config['url']['default_action']);
-        }
+        self::$app_data->setAttribute('controller',  (isset($url[0]) ? $url[0] : self::$config['url']['default_controller']));
+        self::$app_data->setAttribute('action',      (isset($url[1]) ? $url[1] : self::$config['url']['default_action']));
+        self::$app_data->setAttribute('parameter_1', (isset($url[2]) ? $url[2] : null));
+        self::$app_data->setAttribute('parameter_2', (isset($url[3]) ? $url[3] : null));
+        self::$app_data->setAttribute('parameter_3', (isset($url[4]) ? $url[4] : null));
 
         if ($this->isAjax()) {
             self::$ajaxMode = true;
             self::$app_data->action .= '_ajax';
         }
-
 
         self::$post = new dataObj();
         self::$post->fromArray($_POST);


### PR DESCRIPTION
There are some strange and inconvenient things in route handling:
1. Current procedure use `$_GET['url']` only. It works with Apache and mod_rewrite but doesn’t work with PHP built-in development server — tested with 7.4 and 8.2 on Debian GNU/Linux 11.
2. Variable `self::$url` is useless because it assigned but never used.
3. Functions for `$url` and `self::$url` are different but it’s possible to use common function set.
4. The `else` block is unnecessary.

Suggested code manually tested with PHP built-in development server. I’m going to test it with Apache too.